### PR TITLE
Correct typo i Beam cross section documentation

### DIFF
--- a/src/UsersGuide/beta_feature_doc.tex
+++ b/src/UsersGuide/beta_feature_doc.tex
@@ -599,7 +599,6 @@ local triad direction the additional mass should be applied in.
 {\tt\#MassX} is equivalent to {\tt\#MassDir 1 0 0}, {\tt\#MassY} is equivalent
 to {\tt\#MassDir 0 1 0} and {\tt\#MassZ} is equivalent to {\tt\#MassDir 0 0 1}.
 
-\clearpage
 An additional mass is regarded as a {\sl virtual added mass} when
 
 \LinkFormatText{\#AddedMass \Variable{mx} \Variable{my} \Variable{mz}}

--- a/src/UsersGuide/mechanism_elements.tex
+++ b/src/UsersGuide/mechanism_elements.tex
@@ -382,7 +382,7 @@ displayed in the Property Editor panel, as shown below.
   you specify the axial stiffness ({\sl EA}),
   the bending stiffnesses ({\sl EIyy} and {\sl EIzz}),
   the torsional stiffness ({\sl GIt}),
-  the mass per unit length ($\rho${\sl L})
+  the mass per unit length ($\rho${\sl A})
   and the torsional moment of inertia ($\rho${\sl Ip}).
 
 \item{\sl Dependent properties} --


### PR DESCRIPTION
This fixes openfedem/fedem-gui#54.